### PR TITLE
feat: add table statistics api

### DIFF
--- a/server/src/local_tables.rs
+++ b/server/src/local_tables.rs
@@ -63,7 +63,7 @@ impl LocalTablesRecoverer {
         }
     }
 
-    pub async fn recover(&self) -> Result<()> {
+    pub async fn recover(&mut self) -> Result<()> {
         if self.table_infos.is_empty() {
             return Ok(());
         }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -146,7 +146,7 @@ impl Server {
 
     pub async fn start(&mut self) -> Result<()> {
         // Run in standalone mode
-        if let Some(local_tables_recoverer) = &self.local_tables_recoverer {
+        if let Some(local_tables_recoverer) = self.local_tables_recoverer.as_mut() {
             info!("Server start, open local tables");
             local_tables_recoverer
                 .recover()


### PR DESCRIPTION
## Rationale
At present, it often happens that some tables fail to open when opening a shard, but we cannot count the specific opening status. We add an interface to count the opening status of the shard.

## Detailed Changes
* Add an interface to count the opening status of the shard

## Test Plan
