### PR TITLE
feat: utilize the column cardinality for deciding whether to do dict

### DIFF
--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -505,6 +505,7 @@ impl ScheduleWorker {
             num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
             compression: table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
+            column_stats: Default::default(),
         };
         let scan_options = self.scan_options.clone();
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -964,7 +964,6 @@ impl SpaceStore {
                 .context(ReadSstMeta)?;
 
             let column_stats = collect_column_stats_from_meta_datas(&sst_metas);
-
             let merged_meta = MetaData::merge(sst_metas.into_iter().map(MetaData::from), schema);
             (merged_meta, column_stats)
         };
@@ -1100,6 +1099,8 @@ fn collect_column_stats_from_meta_datas(metas: &[SstMetaData]) -> HashMap<String
 
     // Only the column whose cardinality is low in all the metas is a
     // low-cardinality column.
+    // TODO: shall we merge all the distinct values of the column to check whether
+    // the cardinality is still thought to be low?
     let low_cardinality_cols = low_cardinality_counts
         .into_iter()
         .filter_map(|(col_name, cnt)| {

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -950,8 +950,7 @@ impl SpaceStore {
             row_iter::record_batch_with_key_iter_to_stream(merge_iter)
         };
 
-        let mut column_stats = HashMap::new();
-        let sst_meta = {
+        let (sst_meta, column_stats) = {
             let meta_reader = SstMetaReader {
                 space_id: table_data.space_id,
                 table_id: table_data.id,
@@ -964,11 +963,10 @@ impl SpaceStore {
                 .await
                 .context(ReadSstMeta)?;
 
-            if let Some(meta) = sst_metas.get(0) {
-                collect_column_stats(meta, &mut column_stats);
-            }
+            let column_stats = collect_column_stats_from_meta_datas(&sst_metas);
 
-            MetaData::merge(sst_metas.into_iter().map(MetaData::from), schema)
+            let merged_meta = MetaData::merge(sst_metas.into_iter().map(MetaData::from), schema);
+            (merged_meta, column_stats)
         };
 
         // Alloc file id for the merged sst.
@@ -1081,17 +1079,38 @@ impl SpaceStore {
     }
 }
 
-/// Collect the column stats from the sst meta data.
-fn collect_column_stats(meta_data: &SstMetaData, column_stats: &mut HashMap<String, ColumnStats>) {
-    let SstMetaData::Parquet(meta_data) = meta_data;
-    if let Some(column_values) = &meta_data.column_values {
-        for (col_idx, val_set) in column_values.iter().enumerate() {
-            let low_cardinality = val_set.is_some();
-            let col_name = meta_data.schema.column(col_idx).name.clone();
-            let col_stats = ColumnStats { low_cardinality };
-            column_stats.insert(col_name, col_stats);
+/// Collect the column stats from a batch of sst meta data.
+fn collect_column_stats_from_meta_datas(metas: &[SstMetaData]) -> HashMap<String, ColumnStats> {
+    let mut low_cardinality_counts: HashMap<String, usize> = HashMap::new();
+    for meta_data in metas {
+        let SstMetaData::Parquet(meta_data) = meta_data;
+        if let Some(column_values) = &meta_data.column_values {
+            for (col_idx, val_set) in column_values.iter().enumerate() {
+                let low_cardinality = val_set.is_some();
+                if low_cardinality {
+                    let col_name = meta_data.schema.column(col_idx).name.clone();
+                    low_cardinality_counts
+                        .entry(col_name)
+                        .and_modify(|v| *v += 1)
+                        .or_insert(1);
+                }
+            }
         }
     }
+
+    // Only the column whose cardinality is low in all the metas is a
+    // low-cardinality column.
+    let low_cardinality_cols = low_cardinality_counts
+        .into_iter()
+        .filter_map(|(col_name, cnt)| {
+            (cnt == metas.len()).then_some((
+                col_name,
+                ColumnStats {
+                    low_cardinality: true,
+                },
+            ))
+        });
+    HashMap::from_iter(low_cardinality_cols)
 }
 
 fn split_record_batch_with_time_ranges(

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -1177,15 +1177,26 @@ fn build_mem_table_iter(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes_ext::Bytes;
     use common_types::{
+        schema::Schema,
         tests::{
-            build_record_batch_with_key_by_rows, build_row, build_row_opt,
+            build_record_batch_with_key_by_rows, build_row, build_row_opt, build_schema,
             check_record_batch_with_key_with_rows,
         },
         time::TimeRange,
     };
 
-    use crate::instance::flush_compaction::split_record_batch_with_time_ranges;
+    use super::collect_column_stats_from_meta_datas;
+    use crate::{
+        instance::flush_compaction::split_record_batch_with_time_ranges,
+        sst::{
+            meta_data::SstMetaData,
+            parquet::meta_data::{ColumnValueSet, ParquetMetaData},
+        },
+    };
 
     #[test]
     fn test_split_record_batch_with_time_ranges() {
@@ -1237,5 +1248,72 @@ mod tests {
         check_record_batch_with_key_with_rows(&rets[0], rows0.len(), column_num, rows0);
         check_record_batch_with_key_with_rows(&rets[1], rows1.len(), column_num, rows1);
         check_record_batch_with_key_with_rows(&rets[2], rows2.len(), column_num, rows2);
+    }
+
+    fn check_collect_column_stats(
+        schema: &Schema,
+        expected_low_cardinality_col_indexes: Vec<usize>,
+        meta_datas: Vec<SstMetaData>,
+    ) {
+        let column_stats = collect_column_stats_from_meta_datas(&meta_datas);
+        assert_eq!(
+            column_stats.len(),
+            expected_low_cardinality_col_indexes.len()
+        );
+
+        for col_idx in expected_low_cardinality_col_indexes {
+            let col_schema = schema.column(col_idx);
+            assert!(column_stats.contains_key(&col_schema.name));
+        }
+    }
+
+    #[test]
+    fn test_collect_column_stats_from_metadata() {
+        let schema = build_schema();
+        let build_meta_data = |low_cardinality_col_indexes: Vec<usize>| {
+            let mut column_values = vec![None; 6];
+            for idx in low_cardinality_col_indexes {
+                column_values[idx] = Some(ColumnValueSet::StringValue(Default::default()));
+            }
+            let parquet_meta_data = ParquetMetaData {
+                min_key: Bytes::new(),
+                max_key: Bytes::new(),
+                time_range: TimeRange::empty(),
+                max_sequence: 0,
+                schema: schema.clone(),
+                parquet_filter: None,
+                column_values: Some(column_values),
+            };
+            SstMetaData::Parquet(Arc::new(parquet_meta_data))
+        };
+
+        // Normal case 0
+        let meta_datas = vec![
+            build_meta_data(vec![0]),
+            build_meta_data(vec![0]),
+            build_meta_data(vec![0, 1]),
+            build_meta_data(vec![0, 2]),
+            build_meta_data(vec![0, 3]),
+        ];
+        check_collect_column_stats(&schema, vec![0], meta_datas);
+
+        // Normal case 1
+        let meta_datas = vec![
+            build_meta_data(vec![0]),
+            build_meta_data(vec![0]),
+            build_meta_data(vec![]),
+            build_meta_data(vec![1]),
+            build_meta_data(vec![3]),
+        ];
+        check_collect_column_stats(&schema, vec![], meta_datas);
+
+        // Normal case 2
+        let meta_datas = vec![
+            build_meta_data(vec![3, 5]),
+            build_meta_data(vec![0, 3, 5]),
+            build_meta_data(vec![0, 1, 2, 3, 5]),
+            build_meta_data(vec![1, 3, 5]),
+        ];
+        check_collect_column_stats(&schema, vec![3, 5], meta_datas);
     }
 }

--- a/analytic_engine/src/sst/meta_data/mod.rs
+++ b/analytic_engine/src/sst/meta_data/mod.rs
@@ -57,7 +57,7 @@ pub enum Error {
     #[snafu(display("Key value meta path in parquet is empty\nBacktrace\n:{}", backtrace))]
     KvMetaPathEmpty { backtrace: Backtrace },
 
-    #[snafu(display("Unknown mata version, value:{}.\nBacktrace\n:{}", version, backtrace))]
+    #[snafu(display("Unknown meta version, value:{}.\nBacktrace\n:{}", version, backtrace))]
     UnknownMetaVersion {
         version: String,
         backtrace: Backtrace,
@@ -65,9 +65,6 @@ pub enum Error {
 
     #[snafu(display("Metadata in proto struct is not found.\nBacktrace\n:{}", backtrace))]
     MetaDataNotFound { backtrace: Backtrace },
-
-    #[snafu(display("Empty custom metadata in parquet.\nBacktrace\n:{}", backtrace))]
-    EmptyCustomMetaData { backtrace: Backtrace },
 
     #[snafu(display("Failed to decode custom metadata in parquet, err:{}", source))]
     DecodeCustomMetaData { source: encoding::Error },
@@ -80,12 +77,6 @@ pub enum Error {
 
     #[snafu(display("Failed to convert parquet meta data, err:{}", source))]
     ConvertParquetMetaData { source: parquet::meta_data::Error },
-
-    #[snafu(display("Meet a object store error, err:{source}\nBacktrace:\n{backtrace}"))]
-    ObjectStoreError {
-        source: object_store::ObjectStoreError,
-        backtrace: Backtrace,
-    },
 
     #[snafu(display(
         "Failed to decode sst meta data, file_path:{file_path}, err:{source}.\nBacktrace:\n{backtrace:?}",

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -238,7 +238,7 @@ struct ColumnarRecordEncoder<W> {
     arrow_schema: ArrowSchemaRef,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnEncoding {
     pub enable_dict: bool,
 }

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -66,6 +66,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
         num_rows_per_row_group: config.num_rows_per_row_group,
         compression: config.compression,
         max_buffer_size: 1024 * 1024 * 10,
+        column_stats: Default::default(),
     };
 
     info!(

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -122,6 +122,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         compression: Compression::parse_from(&args.compression)
             .with_context(|| format!("invalid compression:{}", args.compression))?,
         max_buffer_size: 10 * 1024 * 1024,
+        column_stats: Default::default(),
     };
     let output = Path::from(args.output);
     let mut writer = factory


### PR DESCRIPTION
## Rationale
The column value set has been summarized into the meta data if the column is low distinct. With such information, the sampling for the columns can be skipped.

## Detailed Changes
Skip sampling over the low-cardinality columns.

## Test Plan
Updated the unit tests.