### PR TITLE
docs: sync GH activities to commits only

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,7 +44,7 @@ github:
 
 notifications:
   commits:      commits@horaedb.apache.org
-  issues:       dev@horaedb.apache.org
+  issues:       commits@horaedb.apache.org
   pullrequests: commits@horaedb.apache.org
   jobs:         commits@horaedb.apache.org
-  discussions:  dev@horaedb.apache.org
+  discussions:  commits@horaedb.apache.org


### PR DESCRIPTION
Reduce dev noise.

cc @tanruixiang 