### PR TITLE
feat: wait for write notification in io runtime

### DIFF
--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -300,6 +300,11 @@ impl Instance {
     }
 
     #[inline]
+    pub fn io_runtime(&self) -> &Arc<Runtime> {
+        &self.runtimes.io_runtime
+    }
+
+    #[inline]
     fn make_flusher(&self) -> Flusher {
         Flusher {
             space_store: self.space_store.clone(),

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -156,6 +156,9 @@ pub enum Error {
     #[snafu(display("Reject for too many pending writes, table:{table}"))]
     TooManyPendingWrites { table: String },
 
+    #[snafu(display("Failed to join, err:{source}"))]
+    Join { source: runtime::Error },
+
     #[snafu(display("Failed to do merge write, msg:{}", msg))]
     MergeWrite { msg: String },
 }


### PR DESCRIPTION
## Rationale
The runtime's schedule latency may lead to the queue waiter's slow execution, and the total write latency may be influenced.

## Detailed Changes
Do the waiting for write notification in the `io_runtime` which won't be busy to ensure the queue waiter's quick response.

## Test Plan
Should pass all the CI.