### PR TITLE
fix: publich nightly image

### DIFF
--- a/.github/workflows/publish-nightly-image.yml
+++ b/.github/workflows/publish-nightly-image.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: horaedb/horaedb-server
+  IMAGE_NAME: apache/horaedb-server
 
 jobs:
   docker:


### PR DESCRIPTION
## Rationale
The following error occurred when publishing the nightly image: 
```
buildx failed with: ERROR: failed to solve: failed to push ghcr.io/horaedb/horaedb-server:nightly-20231222-b77b6969: unexpected status from POST request to https://ghcr.io/ v2/horaedb/horaedb-server/blobs/uploads/: 403 Forbidden
```

## Detailed Changes
Rename image name from `horaedb/horaedb-server` to `apache/horaedb-server`.

## Test Plan
No need.