### PR TITLE
fix: skip wal encoding when data wal is disabled

### DIFF
--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -189,6 +189,7 @@ pub struct Instance {
     pub(crate) iter_options: Option<IterOptions>,
     pub(crate) recover_mode: RecoverMode,
     pub(crate) wal_encode: WalEncodeConfig,
+    pub(crate) disable_wal: bool,
 }
 
 impl Instance {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -149,6 +149,7 @@ impl Instance {
             scan_options,
             recover_mode: ctx.config.recover_mode,
             wal_encode: ctx.config.wal_encode,
+            disable_wal: ctx.config.wal.disable_data,
         });
 
         Ok(instance)

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -422,8 +422,10 @@ impl<'a> Writer<'a> {
 
         self.preprocess_write(&mut encode_ctx).await?;
 
+        let table_data = self.table_data.clone();
         let seq = if self.instance.disable_wal {
-            MIN_SEQUENCE_NUMBER
+            // When wal is disabled, just update the last_seq one by one.
+            table_data.next_sequence()
         } else {
             let encoded_payload = {
                 let _timer = self.table_data.metrics.start_table_write_encode_timer();
@@ -442,7 +444,6 @@ impl<'a> Writer<'a> {
         };
 
         // Write the row group to the memtable and update the state in the mem.
-        let table_data = self.table_data.clone();
         let EncodeContext {
             row_group,
             index_in_writer,

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -110,6 +110,7 @@ pub struct Config {
     /// The interval for sampling the memory usage
     pub mem_usage_sampling_interval: ReadableDuration,
     /// The config for log in the wal.
+    // TODO: move this in WalConfig.
     pub wal_encode: WalEncodeConfig,
 
     /// Wal storage config

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -110,7 +110,7 @@ pub struct Config {
     /// The interval for sampling the memory usage
     pub mem_usage_sampling_interval: ReadableDuration,
     /// The config for log in the wal.
-    // TODO: move this in WalConfig.
+    // TODO: move this to WalConfig.
     pub wal_encode: WalEncodeConfig,
 
     /// Wal storage config

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -446,6 +446,11 @@ impl TableData {
         self.last_sequence.store(seq, Ordering::Release);
     }
 
+    #[inline]
+    pub fn next_sequence(&self) -> SequenceNumber {
+        self.last_sequence.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
     /// Get last flush time
     #[inline]
     pub fn last_flush_time(&self) -> u64 {


### PR DESCRIPTION
## Rationale
When data wal is disable, data is still encoded, which waste cpu usage.

## Detailed Changes
Skip encode when data wal is disabled.

## Test Plan
CI.