### PR TITLE
chore: rename ceresformat to logformat

### DIFF
--- a/components/logger/src/lib.rs
+++ b/components/logger/src/lib.rs
@@ -78,12 +78,12 @@ fn get_string_by_level(lv: Level) -> &'static str {
     }
 }
 
-pub fn term_drainer() -> CeresFormat<TermDecorator> {
+pub fn term_drainer() -> LogFormat<TermDecorator> {
     let decorator = TermDecorator::new().stdout().build();
-    CeresFormat::new(decorator)
+    LogFormat::new(decorator)
 }
 
-pub fn file_drainer(path: &Option<String>) -> Option<CeresFormat<PlainDecorator<File>>> {
+pub fn file_drainer(path: &Option<String>) -> Option<LogFormat<PlainDecorator<File>>> {
     match path {
         Some(path) => {
             let file = OpenOptions::new()
@@ -92,7 +92,7 @@ pub fn file_drainer(path: &Option<String>) -> Option<CeresFormat<PlainDecorator<
                 .open(path)
                 .unwrap();
             let decorator = PlainDecorator::new(file);
-            Some(CeresFormat::new(decorator))
+            Some(LogFormat::new(decorator))
         }
         None => None,
     }
@@ -223,14 +223,14 @@ where
 // ```text
 // 2020-01-20 13:00:14.998 INFO [src/engine/rocksdb/rocks_kv.rs:394] RocksKV::open_with_op start, name:autogen
 // ```
-pub struct CeresFormat<D>
+pub struct LogFormat<D>
 where
     D: Decorator,
 {
     decorator: D,
 }
 
-impl<D> CeresFormat<D>
+impl<D> LogFormat<D>
 where
     D: Decorator,
 {
@@ -239,7 +239,7 @@ where
     }
 }
 
-impl<D> Drain for CeresFormat<D>
+impl<D> Drain for LogFormat<D>
 where
     D: Decorator,
 {
@@ -458,10 +458,7 @@ pub fn init_test_logger() {
 
     // drain
     let term_drain = term_drainer();
-    let drain = LogDispatcher::new(
-        term_drain,
-        Option::<CeresFormat<PlainDecorator<File>>>::None,
-    );
+    let drain = LogDispatcher::new(term_drain, Option::<LogFormat<PlainDecorator<File>>>::None);
 
     // Use async and init stdlog
     let _ = init_log_from_drain(drain, level, false, 12400, true);


### PR DESCRIPTION
## Rationale
Refer https://github.com/apache/incubator-horaedb/issues/1319

## Detailed Changes
* Rename `ceresformat` to `logformat`

## Test Plan
No need.