### PR TITLE
feat: block rules support query

### DIFF
--- a/proxy/src/limiter.rs
+++ b/proxy/src/limiter.rs
@@ -62,10 +62,9 @@ impl BlockRule {
                             return true;
                         }
                     }
-                    false
-                } else {
-                    false
                 }
+
+                false
             }
             BlockRule::AnyInsert => matches!(plan, Plan::Insert(_)),
         }

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -61,6 +61,12 @@ lazy_static! {
     pub static ref HTTP_HANDLER_COUNTER_VEC_GLOBAL: IntCounterVec =
         register_int_counter_vec!("http_handler_counter", "Http handler counter", &["type"])
             .unwrap();
+    pub static ref BLOCKED_REQUEST_COUNTER_VEC_GLOBAL: IntCounterVec = register_int_counter_vec!(
+        "blocked_request_counter",
+        "Blocked request counter",
+        &["type"]
+    )
+    .unwrap();
 }
 
 lazy_static! {

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -240,7 +240,7 @@ impl Proxy {
                 .try_limit(&plan)
                 .box_err()
                 .context(Internal {
-                    msg: "Request is blocked",
+                    msg: format!("Request is blocked, table_name:{table_name:?}"),
                 })?;
         }
 

--- a/query_frontend/src/plan.rs
+++ b/query_frontend/src/plan.rs
@@ -201,6 +201,18 @@ impl QueryPlan {
 
         Some(priority)
     }
+
+    /// When query contains invalid time range such as `[200, 100]`, it will
+    /// return None.
+    pub fn query_range(&self) -> Option<i64> {
+        self.extract_time_range().map(|time_range| {
+            time_range
+                .exclusive_end()
+                .as_i64()
+                .checked_sub(time_range.inclusive_start().as_i64())
+                .unwrap_or(i64::MAX)
+        })
+    }
 }
 
 impl Debug for QueryPlan {

--- a/query_frontend/src/plan.rs
+++ b/query_frontend/src/plan.rs
@@ -77,6 +77,21 @@ pub enum Plan {
     Exists(ExistsTablePlan),
 }
 
+impl Plan {
+    pub fn plan_type(&self) -> &str {
+        match self {
+            Self::Query(_) => "query",
+            Self::Insert(_) => "insert",
+            Self::Create(_)
+            | Self::Drop(_)
+            | Self::Describe(_)
+            | Self::AlterTable(_)
+            | Self::Show(_)
+            | Self::Exists(_) => "other",
+        }
+    }
+}
+
 pub struct PriorityContext {
     pub time_range_threshold: u64,
 }


### PR DESCRIPTION
## Rationale
Query with long time range usually cost too much resources, which affect stable of the whole cluster

## Detailed Changes
- Support block query by query range


## Test Plan
Manually
```bash

curl 0:5000/admin/block -H 'content-type: application/json' -d '
{
  "operation": "Set",
  "write_block_list": [],
  "read_block_list": [],
  "block_rules": [
    {"type": "QueryRange", "content": "24h"}
  ]
}'
```