### PR TITLE
feat: support setting meta_addr&etcd_addrs by env

### DIFF
--- a/src/horaedb/bin/horaedb-server.rs
+++ b/src/horaedb/bin/horaedb-server.rs
@@ -28,7 +28,11 @@ use logger::info;
 
 /// By this environment variable, the address of current node can be overridden.
 /// And it could be domain name or ip address, but no port follows it.
-const NODE_ADDR: &str = "HORAEDB_SERVER_ADDR";
+const HORAEDB_SERVER_ADDR: &str = "HORAEDB_SERVER_ADDR";
+/// By this environment variable, the address of horaemeta can be overridden.
+const HORAEMETA_SERVER_ADDR: &str = "HORAEMETA_SERVER_ADDR";
+/// By this environment variable, the etcd addresses can be overridden.
+const ETCD_ADDRS: &str = "ETCD_ADDRS";
 /// By this environment variable, the cluster name of current node can be
 /// overridden.
 const CLUSTER_NAME: &str = "CLUSTER_NAME";
@@ -82,8 +86,14 @@ fn main() {
         None => Config::default(),
     };
 
-    if let Ok(node_addr) = env::var(NODE_ADDR) {
+    if let Ok(node_addr) = env::var(HORAEDB_SERVER_ADDR) {
         config.node.addr = node_addr;
+    }
+    if let Ok(meta_addr) = env::var(HORAEMETA_SERVER_ADDR) {
+        config.set_meta_addr(meta_addr);
+    }
+    if let Ok(etcd_addrs) = env::var(ETCD_ADDRS) {
+        config.set_etcd_addrs(etcd_addrs);
     }
     if let Ok(cluster) = env::var(CLUSTER_NAME) {
         if let Some(ClusterDeployment::WithMeta(v)) = &mut config.cluster_deployment {

--- a/src/horaedb/src/config.rs
+++ b/src/horaedb/src/config.rs
@@ -78,22 +78,16 @@ pub struct Config {
 
 impl Config {
     pub fn set_meta_addr(&mut self, meta_addr: String) {
-        match &mut self.cluster_deployment {
-            Some(ClusterDeployment::WithMeta(mut v)) => {
-                v.meta_client.meta_addr = meta_addr;
-            }
-            _ => {}
+        if let Some(ClusterDeployment::WithMeta(v)) = &mut self.cluster_deployment {
+            v.meta_client.meta_addr = meta_addr;
         }
     }
 
     // etcd_addrs: should be a string split by ",".
     // Example: "etcd1:2379,etcd2:2379,etcd3:2379"
     pub fn set_etcd_addrs(&mut self, etcd_addrs: String) {
-        match &mut self.cluster_deployment {
-            Some(ClusterDeployment::WithMeta(mut v)) => {
-                v.etcd_client.server_addrs = etcd_addrs.split(",").map(|s| s.to_string()).collect();
-            }
-            _ => {}
+        if let Some(ClusterDeployment::WithMeta(v)) = &mut self.cluster_deployment {
+            v.etcd_client.server_addrs = etcd_addrs.split(',').map(|s| s.to_string()).collect();
         }
     }
 }

--- a/src/horaedb/src/config.rs
+++ b/src/horaedb/src/config.rs
@@ -76,6 +76,28 @@ pub struct Config {
     pub limiter: LimiterConfig,
 }
 
+impl Config {
+    pub fn set_meta_addr(&mut self, meta_addr: String) {
+        match &mut self.cluster_deployment {
+            Some(ClusterDeployment::WithMeta(mut v)) => {
+                v.meta_client.meta_addr = meta_addr;
+            }
+            _ => {}
+        }
+    }
+
+    // etcd_addrs: should be a string split by ",".
+    // Example: "etcd1:2379,etcd2:2379,etcd3:2379"
+    pub fn set_etcd_addrs(&mut self, etcd_addrs: String) {
+        match &mut self.cluster_deployment {
+            Some(ClusterDeployment::WithMeta(mut v)) => {
+                v.etcd_client.server_addrs = etcd_addrs.split(",").map(|s| s.to_string()).collect();
+            }
+            _ => {}
+        }
+    }
+}
+
 /// The cluster deployment decides how to deploy the HoraeDB cluster.
 ///
 /// [ClusterDeployment::NoMeta] means to start one or multiple HoraeDB


### PR DESCRIPTION
## Rationale
Support setting `meta_addr` and `etcd_addrs` through environment variables.

## Detailed Changes
`meta_addr` => HORAEMETA_SERVER_ADDR
`etcd_addrs` => ETCD_ADDRS

## Test Plan
CI & Manual test.