### PR TITLE
chore: skip wal seq check when wal is disabled

### DIFF
--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -528,18 +528,19 @@ impl<'a> Writer<'a> {
                 e
             })?;
 
-        // When seq is MIN_SEQUENCE_NUMBER, it means the wal used for write is not
-        // normal, ignore check in this case.
-        // NOTE: Currently write wal will only increment seq by one,
-        // this may change in future.
-        let last_seq = table_data.last_sequence();
-        if sequence != last_seq && sequence != last_seq + 1 {
-            warn!(
-                "Sequence must be consecutive, table:{}, table_id:{}, last_sequence:{}, wal_sequence:{}",
-                table_data.name,table_data.id,
-                table_data.last_sequence(),
-                sequence
-            );
+        // When wal is disabled, there is no need to do this check.
+        if !self.instance.disable_wal {
+            // NOTE: Currently write wal will only increment seq by one,
+            // this may change in future.
+            let last_seq = table_data.last_sequence();
+            if sequence != last_seq + 1 {
+                warn!(
+                    "Sequence must be consecutive, table:{}, table_id:{}, last_sequence:{}, wal_sequence:{}",
+                    table_data.name,table_data.id,
+                    table_data.last_sequence(),
+                    sequence
+                );
+            }
         }
 
         debug!(

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -25,7 +25,6 @@ use codec::{
 use common_types::{
     row::RowGroup,
     schema::{IndexInWriterSchema, Schema},
-    MIN_SEQUENCE_NUMBER,
 };
 use itertools::Itertools;
 use logger::{debug, error, info, trace, warn};
@@ -533,7 +532,8 @@ impl<'a> Writer<'a> {
         // normal, ignore check in this case.
         // NOTE: Currently write wal will only increment seq by one,
         // this may change in future.
-        if sequence != MIN_SEQUENCE_NUMBER && table_data.last_sequence() + 1 != sequence {
+        let last_seq = table_data.last_sequence();
+        if sequence != last_seq && sequence != last_seq + 1 {
             warn!(
                 "Sequence must be consecutive, table:{}, table_id:{}, last_sequence:{}, wal_sequence:{}",
                 table_data.name,table_data.id,

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -43,7 +43,7 @@ use futures::{
     Future,
 };
 use generic_error::BoxError;
-use logger::{error, info, slow_query};
+use logger::{debug, error, info, slow_query};
 use notifier::notifier::{ExecutionGuard, RequestNotifiers, RequestResult};
 use proxy::{
     hotspot::{HotspotRecorder, Message},
@@ -711,7 +711,8 @@ impl RemoteEngineServiceImpl {
             priority,
         );
 
-        info!("Execute remote query, id:{}", query_ctx.request_id.as_str());
+        debug!("Execute remote query, id:{}", query_ctx.request_id.as_str());
+
         let metric = ExecutePlanMetricCollector::new(
             query_ctx.request_id.clone(),
             ctx.displayable_query,
@@ -772,7 +773,7 @@ impl RemoteEngineServiceImpl {
             ctx.timeout_ms,
             priority,
         );
-        info!(
+        debug!(
             "Execute dedupped remote query, id:{}",
             query_ctx.request_id.as_str()
         );


### PR DESCRIPTION
## Rationale


## Detailed Changes
- Disable seq check when wal is disabled
- Fix request id in remote query.

## Test Plan
