### PR TITLE
chore: enable merge on github

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,7 +34,7 @@ github:
     - horaedb
   enabled_merge_buttons:
     squash:  true
-    merge:   false
+    merge:   true
     rebase:  true
   protected_branches:
     main:


### PR DESCRIPTION
## Rationale
Sometimes merging a branch with some reviewed PRs into another is necessary, but it is disabled now.

## Detailed Changes
Enable to merge some branch to another without squashing.

## Test Plan
Nothing to test.