### PR TITLE
chore(docs): fix invalid repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Read our [Contributing Guide](CONTRIBUTING.md) and make your first contribution!
 
 ## Acknowledgment
 
-When develop HoraeDB, we benefit a lot from several other open source projects,  such as [influxdb_iox](https://github.com/influxdata/influxdb/tree/main/influxdb_iox), [tikv](https://github.com/tikv/tikv) etc, thanks for their awesome work.
+When develop HoraeDB, we benefit a lot from several other open source projects,  such as [influxdb_iox](https://github.com/influxdata/influxdb/tree/main), [tikv](https://github.com/tikv/tikv) etc, thanks for their awesome work.
 
 In our production usage, we heavily use [OceanBase](https://github.com/oceanbase/oceanbase) as implementation of both WAL and ObjectStorage, and OceanBase team help us maintain stability of our cluster, thanks for their kindly support.
 


### PR DESCRIPTION
## Rationale
The old links is invalid.

## Detailed Changes
Influxdb_iox repo change into influxdb main branch. So I modified the links.

## Test Plan
no need test.