### PR TITLE
fix: changes required for migrate dev to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ dependencies = [
  "async-trait",
  "common_types",
  "generic_error",
+ "lazy_static",
  "logger",
  "macros",
  "snafu 0.6.10",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -37,6 +37,7 @@ test = []
 async-trait = { workspace = true }
 common_types = { workspace = true }
 generic_error = { workspace = true }
+lazy_static = { workspace = true }
 logger = { workspace = true }
 macros = { workspace = true }
 snafu = { workspace = true }

--- a/src/catalog/src/consts.rs
+++ b/src/catalog/src/consts.rs
@@ -19,15 +19,14 @@
 
 use lazy_static::lazy_static;
 
+lazy_static! {
+    /// Default catalog name
+    pub static ref DEFAULT_CATALOG: String =
+        std::env::var("HORAEDB_DEFAULT_CATALOG").unwrap_or_else(|_| "horaedb".to_string());
+}
 /// Default schema name
 pub const DEFAULT_SCHEMA: &str = "public";
 /// Catalog name of the sys catalog
 pub const SYSTEM_CATALOG: &str = "system";
 /// Schema name of the sys catalog
 pub const SYSTEM_CATALOG_SCHEMA: &str = "public";
-
-lazy_static! {
-    /// Default catalog name
-    pub static ref DEFAULT_CATALOG: String =
-        std::env::var("HORAEDB_DEFAULT_CATALOG").unwrap_or_else(|_| "horaedb".to_string());
-}

--- a/src/catalog/src/consts.rs
+++ b/src/catalog/src/consts.rs
@@ -18,7 +18,8 @@
 //! Catalog constants
 
 /// Default catalog name
-pub const DEFAULT_CATALOG: &str = "horaedb";
+// pub const DEFAULT_CATALOG: &str = "horaedb";
+pub const DEFAULT_CATALOG: &str = "ceresdb";
 /// Default schema name
 pub const DEFAULT_SCHEMA: &str = "public";
 /// Catalog name of the sys catalog

--- a/src/catalog/src/consts.rs
+++ b/src/catalog/src/consts.rs
@@ -17,12 +17,17 @@
 
 //! Catalog constants
 
-/// Default catalog name
-// pub const DEFAULT_CATALOG: &str = "horaedb";
-pub const DEFAULT_CATALOG: &str = "ceresdb";
+use lazy_static::lazy_static;
+
 /// Default schema name
 pub const DEFAULT_SCHEMA: &str = "public";
 /// Catalog name of the sys catalog
 pub const SYSTEM_CATALOG: &str = "system";
 /// Schema name of the sys catalog
 pub const SYSTEM_CATALOG_SCHEMA: &str = "public";
+
+lazy_static! {
+    /// Default catalog name
+    pub static ref DEFAULT_CATALOG: String =
+        std::env::var("HORAEDB_DEFAULT_CATALOG").unwrap_or_else(|_| "horaedb".to_string());
+}

--- a/src/catalog_impls/src/table_based.rs
+++ b/src/catalog_impls/src/table_based.rs
@@ -114,7 +114,7 @@ pub struct TableBasedManager {
 
 impl Manager for TableBasedManager {
     fn default_catalog_name(&self) -> NameRef {
-        consts::DEFAULT_CATALOG
+        &consts::DEFAULT_CATALOG
     }
 
     fn default_schema_name(&self) -> NameRef {
@@ -255,7 +255,7 @@ impl TableBasedManager {
 
     async fn maybe_create_default_catalog(&mut self) -> Result<()> {
         // Try to get default catalog, create it if not exists.
-        let catalog = match self.catalogs.get(consts::DEFAULT_CATALOG) {
+        let catalog = match self.catalogs.get(consts::DEFAULT_CATALOG.as_str()) {
             Some(v) => v.clone(),
             None => {
                 // Only system catalog should exists.

--- a/src/catalog_impls/src/volatile.rs
+++ b/src/catalog_impls/src/volatile.rs
@@ -71,7 +71,7 @@ impl ManagerImpl {
 
 impl Manager for ManagerImpl {
     fn default_catalog_name(&self) -> NameRef {
-        consts::DEFAULT_CATALOG
+        &consts::DEFAULT_CATALOG
     }
 
     fn default_schema_name(&self) -> NameRef {
@@ -96,7 +96,7 @@ impl ManagerImpl {
     fn maybe_create_default_catalog(&mut self) {
         // TODO: we should delegate this operation to the [TableManager].
         // Try to get default catalog, create it if not exists.
-        if self.catalogs.get(consts::DEFAULT_CATALOG).is_none() {
+        if self.catalogs.get(consts::DEFAULT_CATALOG.as_str()).is_none() {
             // Default catalog is not exists, create and store it.
             self.create_catalog(consts::DEFAULT_CATALOG.to_string());
         };

--- a/src/catalog_impls/src/volatile.rs
+++ b/src/catalog_impls/src/volatile.rs
@@ -96,7 +96,11 @@ impl ManagerImpl {
     fn maybe_create_default_catalog(&mut self) {
         // TODO: we should delegate this operation to the [TableManager].
         // Try to get default catalog, create it if not exists.
-        if self.catalogs.get(consts::DEFAULT_CATALOG.as_str()).is_none() {
+        if self
+            .catalogs
+            .get(consts::DEFAULT_CATALOG.as_str())
+            .is_none()
+        {
             // Default catalog is not exists, create and store it.
             self.create_catalog(consts::DEFAULT_CATALOG.to_string());
         };

--- a/src/query_frontend/src/planner.rs
+++ b/src/query_frontend/src/planner.rs
@@ -1389,7 +1389,7 @@ fn ensure_column_default_value_valid<P: MetaProvider>(
 // TODO: support catalog/schema
 pub fn get_table_ref(table_name: &str) -> TableReference {
     TableReference::from(ResolvedTableReference {
-        catalog: Cow::from(DEFAULT_CATALOG),
+        catalog: Cow::from(DEFAULT_CATALOG.as_str()),
         schema: Cow::from(DEFAULT_SCHEMA),
         table: Cow::from(table_name),
     })

--- a/src/query_frontend/src/tests.rs
+++ b/src/query_frontend/src/tests.rs
@@ -93,7 +93,7 @@ impl Default for MockMetaProvider {
 
 impl MetaProvider for MockMetaProvider {
     fn default_catalog_name(&self) -> &str {
-        DEFAULT_CATALOG
+        &DEFAULT_CATALOG
     }
 
     fn default_schema_name(&self) -> &str {

--- a/src/server/src/server.rs
+++ b/src/server/src/server.rs
@@ -177,11 +177,12 @@ impl Server {
         if let Some(cluster) = &self.cluster {
             info!("Server start, start cluster");
             cluster.start().await.context(StartCluster)?;
+        } else {
+            // TODO: Is it necessary to create default schema in cluster mode?
+            info!("Server start, create default schema if not exist");
+            self.create_default_schema_if_not_exists().await;
         }
 
-        // TODO: Is it necessary to create default schema in cluster mode?
-        info!("Server start, create default schema if not exist");
-        self.create_default_schema_if_not_exists().await;
 
         info!("Server start, start services");
 

--- a/src/server/src/server.rs
+++ b/src/server/src/server.rs
@@ -177,11 +177,11 @@ impl Server {
         if let Some(cluster) = &self.cluster {
             info!("Server start, start cluster");
             cluster.start().await.context(StartCluster)?;
-        } else {
-            // TODO: Is it necessary to create default schema in cluster mode?
-            info!("Server start, create default schema if not exist");
-            self.create_default_schema_if_not_exists().await;
         }
+
+        // TODO: Is it necessary to create default schema in cluster mode?
+        info!("Server start, create default schema if not exist");
+        self.create_default_schema_if_not_exists().await;
 
 
         info!("Server start, start services");

--- a/src/server/src/server.rs
+++ b/src/server/src/server.rs
@@ -183,7 +183,6 @@ impl Server {
         info!("Server start, create default schema if not exist");
         self.create_default_schema_if_not_exists().await;
 
-
         info!("Server start, start services");
 
         self.http_service.start().await.context(HttpService {

--- a/src/server/src/session.rs
+++ b/src/server/src/session.rs
@@ -54,7 +54,7 @@ pub type SessionRef = Arc<Session>;
 impl Session {
     pub fn new(addr: Option<SocketAddr>, channel: Channel) -> Self {
         Session {
-            catalog: ArcSwap::new(Arc::new(DEFAULT_CATALOG.into())),
+            catalog: ArcSwap::new(Arc::new(DEFAULT_CATALOG.clone())),
             schema: ArcSwap::new(Arc::new(DEFAULT_SCHEMA.into())),
             conn_info: ConnInfo::new(addr, channel),
         }
@@ -166,7 +166,7 @@ pub fn parse_catalog_and_schema_from_db_string(db: &str) -> (&str, &str) {
     if parts.len() == 2 {
         (parts[0], parts[1])
     } else {
-        (DEFAULT_CATALOG, db)
+        (&DEFAULT_CATALOG, db)
     }
 }
 

--- a/src/server/src/session.rs
+++ b/src/server/src/session.rs
@@ -177,7 +177,7 @@ mod tests {
 
     /// Build db name from catalog and schema string
     fn build_db_string(catalog: &str, schema: &str) -> String {
-        if catalog == DEFAULT_CATALOG {
+        if catalog == DEFAULT_CATALOG.as_str() {
             schema.to_string()
         } else {
             format!("{catalog}-{schema}")
@@ -186,14 +186,14 @@ mod tests {
 
     #[test]
     fn test_db_string() {
-        assert_eq!("test", build_db_string(DEFAULT_CATALOG, "test"));
+        assert_eq!("test", build_db_string(&DEFAULT_CATALOG, "test"));
         assert_eq!("a0b1c2d3-test", build_db_string("a0b1c2d3", "test"));
     }
 
     #[test]
     fn test_parse_catalog_and_schema() {
         assert_eq!(
-            (DEFAULT_CATALOG, "fullschema"),
+            (DEFAULT_CATALOG.as_str(), "fullschema"),
             parse_catalog_and_schema_from_db_string("fullschema")
         );
 


### PR DESCRIPTION
## Rationale
When rename ceresdb to horaedb, there are some breaking changes.

In order to allow old version to upgrade to main branch, some changes are required.

## Detailed Changes
- Make default catalog configurable via env vars,

## Test Plan
Manually.

Before upgrade, first setup required envs
```bash
export HORAEDB_DEFAULT_CATALOG=ceresdb
``` 
Etcd's root should be configured both in horaedb and horaemeta

For horaedb
```
[cluster_deployment.etcd_client]
server_addrs = ['127.0.0.1:2379']
root_path = "/rootPath"
```

For horaemeta
```
storage-root-path = "/rootPath"
```


Then 
1. Upgrade horaemeta, then horaedb will throw following errors, which is expected
```
2024-01-23 14:37:57.726 ERRO [src/cluster/src/cluster_impl.rs:136] Send heartbeat to meta failed, err:Failed to send heartbeat, cluster:defaultCluster, err:status: Unimplemented, message: "unknown service meta_service.MetaRpcService", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }

```

2. Upgrade horaedb, after all server upgraded, the cluster should be ready for read/write, and old data could be queried like before.

