### PR TITLE
fix: random failure of test_collect_system_stats

### DIFF
--- a/src/components/system_stats/src/lib.rs
+++ b/src/components/system_stats/src/lib.rs
@@ -147,10 +147,11 @@ mod tests {
                 .collect_and_report(Duration::from_millis(200))
                 .await;
             check_system_stats(&new_stats);
-            all_cpu_usages.push(new_stats.cpu_usage);
+            all_cpu_usages.push(new_stats);
         }
 
-        // Ensure the stats will be updated for every collection.
-        assert!(all_cpu_usages.into_iter().any(|v| v != stats.cpu_usage));
+        assert!(all_cpu_usages
+            .into_iter()
+            .all(|v| v.num_cpus == stats.num_cpus && v.total_memory == stats.total_memory));
     }
 }


### PR DESCRIPTION
## Rationale
The unit test `test_collect_system_stats` often fails when running on the github ci server.

## Detailed Changes
Remove the check for cpu usages.

## Test Plan
Should pass the CI.