### PR TITLE
chore: rename ci's prefix name

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: HoraeMeta Check
+name: HoraeMeta
 on:
   pull_request:
     paths-ignore:
@@ -24,12 +24,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  horaemeta-style-check:
+  style-check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - name: HoraeMeta Check License Header
+      - name: Check License Header
         uses: korandoru/hawkeye@v3
       - uses: actions/setup-go@v3
         with:
@@ -39,7 +39,7 @@ jobs:
           make install-tools
           make check
           
-  horaemeta-unit-test:
+  unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -52,7 +52,7 @@ jobs:
           make install-tools
           make test
 
-  horaemeta-integration-test:
+  integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Check
+name: HoraeMeta Check
 on:
   pull_request:
     paths-ignore:
@@ -24,12 +24,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  style-check:
+  horaemeta-style-check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - name: Check License Header
+      - name: HoraeMeta Check License Header
         uses: korandoru/hawkeye@v3
       - uses: actions/setup-go@v3
         with:
@@ -39,7 +39,7 @@ jobs:
           make install-tools
           make check
           
-  unit-test:
+  horaemeta-unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -52,7 +52,7 @@ jobs:
           make install-tools
           make test
 
-  integration-test:
+  horaemeta-integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: CI
+name: HoraeDB
 
 on:
   merge_group:

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Test Docker image build
+name: Test HoraeDB Docker image build
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Rationale
horaemeta and horaedb ci names are too close to identify.

## Detailed Changes
rename meta's ci name

## Test Plan
UT