### PR TITLE
chore(docs): fix invalid repo links

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -90,7 +90,7 @@ Drop TABLE `demo`
 
 
 ## 致谢
-在开发 HoraeDB 的过程中， 我们受到很多开源项目的影响和启发，例如  [influxdb_iox](https://github.com/influxdata/influxdb/tree/main/influxdb_iox), [tikv](https://github.com/tikv/tikv) 等等。感谢这些杰出的项目。
+在开发 HoraeDB 的过程中， 我们受到很多开源项目的影响和启发，例如  [influxdb_iox](https://github.com/influxdata/influxdb/tree/main), [tikv](https://github.com/tikv/tikv) 等等。感谢这些杰出的项目。
 
 在生产环境中，我们重度使用 [OceanBase](https://github.com/oceanbase/oceanbase) 作为 WAL 和 ObjectStore 的实现，而且 OceanBase 团队还帮助我们一起维护集群的稳定，感谢 OceanBase 团队一直以来的帮助。
 


### PR DESCRIPTION
## Rationale
The old links is invalid.

## Detailed Changes
Influxdb_iox repo changed into influxdb main branch. So I fix the links.


## Test Plan
no need test.