### PR TITLE
feat(horaemeta): drop metadata of partition table by http api

### DIFF
--- a/horaemeta/server/cluster/manager.go
+++ b/horaemeta/server/cluster/manager.go
@@ -307,6 +307,20 @@ func (m *managerImpl) DropTable(ctx context.Context, clusterName, schemaName, ta
 		return errors.WithMessage(err, "get table")
 	}
 
+	// If the table is partitioned, delete the table metadata directly.
+	if table.IsPartitioned() {
+		_, err = cluster.metadata.DropTableMetadata(ctx,
+			schemaName,
+			tableName,
+		)
+		if err != nil {
+			return errors.WithMessage(err, "cluster drop table")
+		}
+		return nil
+	}
+
+	// If the table is not a partition table, delete the table metadata and remove the table from the shard.
+	// So we need to check if the table has been assigned to a shard.
 	getShardNodeResult, err := cluster.metadata.GetShardNodeByTableIDs([]storage.TableID{table.ID})
 	if err != nil {
 		return errors.WithMessage(err, "get shard node by tableID")

--- a/horaemeta/server/cluster/manager.go
+++ b/horaemeta/server/cluster/manager.go
@@ -309,12 +309,9 @@ func (m *managerImpl) DropTable(ctx context.Context, clusterName, schemaName, ta
 
 	// If the table is partitioned, delete the table metadata directly.
 	if table.IsPartitioned() {
-		_, err = cluster.metadata.DropTableMetadata(ctx,
-			schemaName,
-			tableName,
-		)
+		_, err = cluster.metadata.DropTableMetadata(ctx, schemaName, tableName)
 		if err != nil {
-			return errors.WithMessage(err, "cluster drop table")
+			return errors.WithMessage(err, "cluster drop table metadata")
 		}
 		return nil
 	}


### PR DESCRIPTION
## Rationale
Currently, not suppport to delete a partitioned table through HTTP API, as it results in a "shard not found" error.

## Detailed Changes
Since the partition table is not assigned to  a shard, deleting the table metadata directly.

## Test Plan
 Manual test.