### PR TITLE
feat(horaemeta): add node inspector

### DIFF
--- a/horaemeta/server/cluster/metadata/cluster_metadata.go
+++ b/horaemeta/server/cluster/metadata/cluster_metadata.go
@@ -685,7 +685,7 @@ func (c *ClusterMetadata) UpdateClusterViewByNode(ctx context.Context, shardNode
 	return nil
 }
 
-func (c *ClusterMetadata) DropShardNode(ctx context.Context, shardNodes []storage.ShardNode) error {
+func (c *ClusterMetadata) DropShardNodes(ctx context.Context, shardNodes []storage.ShardNode) error {
 	if err := c.topologyManager.DropShardNodes(ctx, shardNodes); err != nil {
 		return errors.WithMessage(err, "drop shard nodes")
 	}

--- a/horaemeta/server/cluster/metadata/cluster_metadata_test.go
+++ b/horaemeta/server/cluster/metadata/cluster_metadata_test.go
@@ -213,7 +213,7 @@ func testShardOperation(ctx context.Context, re *require.Assertions, m *metadata
 	_, err = m.GetShardNodeByTableIDs([]storage.TableID{})
 	re.NoError(err)
 
-	err = m.DropShardNode(ctx, []storage.ShardNode{{
+	err = m.DropShardNodes(ctx, []storage.ShardNode{{
 		ID:        shardNodeResult.NodeShards[0].ShardNode.ID,
 		ShardRole: shardNodeResult.NodeShards[0].ShardNode.ShardRole,
 		NodeName:  shardNodeResult.NodeShards[0].ShardNode.NodeName,

--- a/horaemeta/server/coordinator/inspector/node_inspector.go
+++ b/horaemeta/server/coordinator/inspector/node_inspector.go
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package inspector
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/apache/incubator-horaedb-meta/pkg/log"
+	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
+	"github.com/apache/incubator-horaedb-meta/server/storage"
+	"go.uber.org/zap"
+)
+
+const inspectInterval = time.Second * 5
+
+// NodeInspector will inspect node status and remove expired data.
+type NodeInspector struct {
+	logger          *zap.Logger
+	clusterMetadata *metadata.ClusterMetadata
+
+	// This lock is used to protect the following field.
+	lock      sync.RWMutex
+	isRunning atomic.Bool
+}
+
+func NewNodeInspector(logger *zap.Logger, clusterMetadata *metadata.ClusterMetadata) *NodeInspector {
+	return &NodeInspector{
+		logger:          logger,
+		clusterMetadata: clusterMetadata,
+		lock:            sync.RWMutex{},
+		isRunning:       atomic.Bool{},
+	}
+}
+
+func (i *NodeInspector) Start(ctx context.Context) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.isRunning.Load() {
+		return nil
+	}
+
+	log.Info("node inspector start")
+
+	go func() {
+		i.isRunning.Store(true)
+		for {
+			if !i.isRunning.Load() {
+				i.logger.Info("scheduler manager is canceled")
+				return
+			}
+
+			time.Sleep(inspectInterval)
+
+			// Get latest cluster snapshot.
+			snapshot := i.clusterMetadata.GetClusterSnapshot()
+			i.inspect(ctx, snapshot)
+		}
+	}()
+
+	return nil
+}
+
+func (i *NodeInspector) Stop(_ context.Context) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.isRunning.Load() {
+		i.isRunning.Store(false)
+	}
+
+	return nil
+}
+
+func (i *NodeInspector) inspect(ctx context.Context, snapshot metadata.Snapshot) {
+	shardNodeMapping := make(map[string][]storage.ShardNode, len(snapshot.RegisteredNodes))
+	for _, shardNode := range snapshot.Topology.ClusterView.ShardNodes {
+		if _, exists := shardNodeMapping[shardNode.NodeName]; !exists {
+			shardNodeMapping[shardNode.NodeName] = []storage.ShardNode{}
+		}
+		shardNodeMapping[shardNode.NodeName] = append(shardNodeMapping[shardNode.NodeName], shardNode)
+	}
+
+	expiredShardNodes := make([]storage.ShardNode, 0, len(snapshot.RegisteredNodes))
+	// Check node status.
+	now := time.Now()
+	for _, node := range snapshot.RegisteredNodes {
+		if node.IsExpired(now) {
+			expired, exists := shardNodeMapping[node.Node.Name]
+			if !exists {
+				log.Debug("try to remove non-existent node")
+				continue
+			}
+			expiredShardNodes = append(expiredShardNodes, expired...)
+		}
+	}
+
+	// Try to remove useless data if it exists.
+	if err := i.clusterMetadata.DropShardNode(ctx, expiredShardNodes); err != nil {
+		log.Error("drop shard node failed", zap.Error(err))
+	}
+}

--- a/horaemeta/server/coordinator/inspector/node_inspector_test.go
+++ b/horaemeta/server/coordinator/inspector/node_inspector_test.go
@@ -61,7 +61,7 @@ func (n *mockClusterMetaDataManipulator) GetClusterSnapshot() metadata.Snapshot 
 	return n.snapshot
 }
 
-func (n *mockClusterMetaDataManipulator) DropShardNode(_ context.Context, shardNodes []storage.ShardNode) error {
+func (n *mockClusterMetaDataManipulator) DropShardNodes(_ context.Context, shardNodes []storage.ShardNode) error {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 

--- a/horaemeta/server/coordinator/inspector/node_inspector_test.go
+++ b/horaemeta/server/coordinator/inspector/node_inspector_test.go
@@ -1,8 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package inspector
 
 import (
 	"context"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,41 +34,16 @@ import (
 
 type mockClusterMetaDataManipulator struct {
 	snapshot          metadata.Snapshot
+	lock              sync.Mutex
 	droppedShardNodes [][]storage.ShardNode
 }
 
-func newMockClusterMetaDataManipulator() ClusterMetaDataManipulator {
+func newMockClusterMetaDataManipulator(shardNodes []storage.ShardNode, registeredNodes []metadata.RegisteredNode) *mockClusterMetaDataManipulator {
 	var clusterView storage.ClusterView
-	clusterView.ShardNodes = []storage.ShardNode{
-		{ID: storage.ShardID(0), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
-		{ID: storage.ShardID(1), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
-		{ID: storage.ShardID(2), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.103"},
-		{ID: storage.ShardID(3), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.104"},
-	}
-
+	clusterView.ShardNodes = shardNodes
 	topology := metadata.Topology{
 		ShardViewsMapping: nil,
 		ClusterView:       clusterView,
-	}
-	registeredNodes := []metadata.RegisteredNode{
-		{
-			Node: storage.Node{
-				Name:          "192.168.1.102",
-				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
-				LastTouchTime: uint64(time.Now().UnixMilli()),
-				State:         storage.NodeStateOnline,
-			},
-			ShardInfos: nil,
-		},
-		{
-			Node: storage.Node{
-				Name:          "192.168.1.103",
-				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
-				LastTouchTime: uint64(time.Now().UnixMilli()) - uint64((time.Second * 20)),
-				State:         storage.NodeStateOnline,
-			},
-			ShardInfos: nil,
-		},
 	}
 
 	snapshot := metadata.Snapshot{
@@ -57,6 +52,7 @@ func newMockClusterMetaDataManipulator() ClusterMetaDataManipulator {
 	}
 	return &mockClusterMetaDataManipulator{
 		snapshot:          snapshot,
+		lock:              sync.Mutex{},
 		droppedShardNodes: make([][]storage.ShardNode, 0),
 	}
 }
@@ -66,6 +62,9 @@ func (n *mockClusterMetaDataManipulator) GetClusterSnapshot() metadata.Snapshot 
 }
 
 func (n *mockClusterMetaDataManipulator) DropShardNode(_ context.Context, shardNodes []storage.ShardNode) error {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	n.droppedShardNodes = append(n.droppedShardNodes, shardNodes)
 	newShardNodes := make([]storage.ShardNode, 0, 2)
 	for _, node := range n.snapshot.Topology.ClusterView.ShardNodes {
@@ -80,8 +79,15 @@ func (n *mockClusterMetaDataManipulator) DropShardNode(_ context.Context, shardN
 	return nil
 }
 
+func (n *mockClusterMetaDataManipulator) CheckDroppedShardNodes(check func(droppedShardNodes [][]storage.ShardNode)) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	check(n.droppedShardNodes)
+}
+
 func TestStartStopInspector(t *testing.T) {
-	inspector := NewNodeInspector(zap.NewNop(), newMockClusterMetaDataManipulator())
+	inspector := NewNodeInspector(zap.NewNop(), newMockClusterMetaDataManipulator(nil, nil))
 
 	ctx := context.Background()
 	assert.NoError(t, inspector.Start(ctx))
@@ -91,5 +97,49 @@ func TestStartStopInspector(t *testing.T) {
 }
 
 func TestInspect(t *testing.T) {
-	// TODO: add a integrate inspect test case
+	shardNodes := []storage.ShardNode{
+		{ID: storage.ShardID(0), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
+		{ID: storage.ShardID(1), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
+		{ID: storage.ShardID(2), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.103"},
+		{ID: storage.ShardID(3), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.103"},
+	}
+	registeredNodes := []metadata.RegisteredNode{
+		{
+			Node: storage.Node{
+				Name:          "192.168.1.102",
+				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
+				LastTouchTime: uint64(time.Now().UnixMilli()),
+				State:         storage.NodeStateOnline,
+			},
+			ShardInfos: nil,
+		},
+		{
+			// This node should be outdated.
+			Node: storage.Node{
+				Name:          "192.168.1.103",
+				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
+				LastTouchTime: uint64(time.Now().UnixMilli()) - uint64((time.Second * 20)),
+				State:         storage.NodeStateOnline,
+			},
+			ShardInfos: nil,
+		},
+	}
+
+	metadata := newMockClusterMetaDataManipulator(shardNodes, registeredNodes)
+	inspector := NewNodeInspectorWithInterval(zap.NewNop(), metadata, time.Millisecond*100)
+	ctx := context.Background()
+	assert.NoError(t, inspector.Start(ctx))
+
+	// The inspect should be triggered after 200ms.
+	time.Sleep(time.Millisecond * 200)
+
+	// The outdated node should be removed by triggered.
+	metadata.CheckDroppedShardNodes(func(droppedShardNodes [][]storage.ShardNode) {
+		assert.True(t, len(droppedShardNodes) == 1)
+		assert.True(t, len(droppedShardNodes[0]) == 2)
+		assert.Equal(t, droppedShardNodes[0][0], shardNodes[2])
+		assert.Equal(t, droppedShardNodes[0][1], shardNodes[3])
+	})
+
+	assert.NoError(t, inspector.Stop(ctx))
 }

--- a/horaemeta/server/coordinator/inspector/node_inspector_test.go
+++ b/horaemeta/server/coordinator/inspector/node_inspector_test.go
@@ -1,0 +1,95 @@
+package inspector
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
+	"github.com/apache/incubator-horaedb-meta/server/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type mockClusterMetaDataManipulator struct {
+	snapshot          metadata.Snapshot
+	droppedShardNodes [][]storage.ShardNode
+}
+
+func newMockClusterMetaDataManipulator() ClusterMetaDataManipulator {
+	var clusterView storage.ClusterView
+	clusterView.ShardNodes = []storage.ShardNode{
+		{ID: storage.ShardID(0), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
+		{ID: storage.ShardID(1), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.102"},
+		{ID: storage.ShardID(2), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.103"},
+		{ID: storage.ShardID(3), ShardRole: storage.ShardRoleLeader, NodeName: "192.168.1.104"},
+	}
+
+	topology := metadata.Topology{
+		ShardViewsMapping: nil,
+		ClusterView:       clusterView,
+	}
+	registeredNodes := []metadata.RegisteredNode{
+		{
+			Node: storage.Node{
+				Name:          "192.168.1.102",
+				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
+				LastTouchTime: uint64(time.Now().UnixMilli()),
+				State:         storage.NodeStateOnline,
+			},
+			ShardInfos: nil,
+		},
+		{
+			Node: storage.Node{
+				Name:          "192.168.1.103",
+				NodeStats:     storage.NodeStats{Lease: 0, Zone: "", NodeVersion: ""},
+				LastTouchTime: uint64(time.Now().UnixMilli()) - uint64((time.Second * 20)),
+				State:         storage.NodeStateOnline,
+			},
+			ShardInfos: nil,
+		},
+	}
+
+	snapshot := metadata.Snapshot{
+		Topology:        topology,
+		RegisteredNodes: registeredNodes,
+	}
+	return &mockClusterMetaDataManipulator{
+		snapshot:          snapshot,
+		droppedShardNodes: make([][]storage.ShardNode, 0),
+	}
+}
+
+func (n *mockClusterMetaDataManipulator) GetClusterSnapshot() metadata.Snapshot {
+	return n.snapshot
+}
+
+func (n *mockClusterMetaDataManipulator) DropShardNode(_ context.Context, shardNodes []storage.ShardNode) error {
+	n.droppedShardNodes = append(n.droppedShardNodes, shardNodes)
+	newShardNodes := make([]storage.ShardNode, 0, 2)
+	for _, node := range n.snapshot.Topology.ClusterView.ShardNodes {
+		dropped := slices.ContainsFunc(shardNodes, func(droppedNode storage.ShardNode) bool {
+			return node.NodeName == droppedNode.NodeName
+		})
+		if !dropped {
+			newShardNodes = append(newShardNodes, node)
+		}
+	}
+	n.snapshot.Topology.ClusterView.ShardNodes = newShardNodes
+	return nil
+}
+
+func TestStartStopInspector(t *testing.T) {
+	inspector := NewNodeInspector(zap.NewNop(), newMockClusterMetaDataManipulator())
+
+	ctx := context.Background()
+	assert.NoError(t, inspector.Start(ctx))
+	assert.Error(t, inspector.Start(ctx))
+
+	assert.NoError(t, inspector.Stop(ctx))
+}
+
+func TestInspect(t *testing.T) {
+	// TODO: add a integrate inspect test case
+}

--- a/horaemeta/server/coordinator/scheduler/manager/scheduler_manager.go
+++ b/horaemeta/server/coordinator/scheduler/manager/scheduler_manager.go
@@ -203,7 +203,7 @@ func (callback *schedulerWatchCallback) OnShardRegistered(_ context.Context, _ w
 func (callback *schedulerWatchCallback) OnShardExpired(ctx context.Context, event watch.ShardExpireEvent) error {
 	oldLeader := event.OldLeaderNode
 	shardID := event.ShardID
-	return callback.c.DropShardNode(ctx, []storage.ShardNode{
+	return callback.c.DropShardNodes(ctx, []storage.ShardNode{
 		{
 			ID:        shardID,
 			ShardRole: storage.ShardRoleLeader,

--- a/horaemeta/server/coordinator/shard_picker_test.go
+++ b/horaemeta/server/coordinator/shard_picker_test.go
@@ -83,7 +83,7 @@ func TestLeastTableShardPicker(t *testing.T) {
 	// drop shard node 1, shard 1 should not be picked.
 	for _, shardNode := range snapshot.Topology.ClusterView.ShardNodes {
 		if shardNode.ID == 1 {
-			err = c.GetMetadata().DropShardNode(ctx, []storage.ShardNode{shardNode})
+			err = c.GetMetadata().DropShardNodes(ctx, []storage.ShardNode{shardNode})
 			re.NoError(err)
 		}
 	}

--- a/horaemeta/server/service/http/api.go
+++ b/horaemeta/server/service/http/api.go
@@ -230,7 +230,7 @@ func (a *API) dropNodeShards(req *http.Request) apiFuncResult {
 		}
 	}
 
-	if err := c.GetMetadata().DropShardNode(req.Context(), targetShardNodes); err != nil {
+	if err := c.GetMetadata().DropShardNodes(req.Context(), targetShardNodes); err != nil {
 		log.Error("drop node shards failed", zap.Error(err))
 		return errResult(ErrDropNodeShards, err.Error())
 	}


### PR DESCRIPTION
## Rationale
In some extreme scenarios, etcd events may be lost or update failures may occur, which may cause the mapping between nodes and shards to fail to be updated correctly. We need to add a cover-up mechanism to ensure that the mapping relationship is always correct.

## Detailed Changes
* Add `NodeInspector`, it will start when the cluster start, running in he background and detect the status of nodes.

## Test Plan
Pass CI.