### PR TITLE
chore: free disk for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Check License Header
         uses: korandoru/hawkeye@v3
       - name: Setup Build Environment
@@ -90,8 +89,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -123,8 +121,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -161,8 +158,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -222,8 +218,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -256,8 +251,7 @@ jobs:
           rustup toolchain install ${RUST_VERSION} --profile minimal
       - name: Release Disk Quota
         run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
+          sudo make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,7 @@ miri:
 	cd $(DIR); cargo miri test --package arena
 
 ensure-disk-quota:
-	# ensure the target directory not to exceed 30GB
-	python3 ./scripts/clean-large-folder.py ./target 30
+	bash ./scripts/free-disk-space.sh
 
 tsbs: build
 	cd $(DIR); sh scripts/run-tsbs.sh

--- a/scripts/free-disk-space.sh
+++ b/scripts/free-disk-space.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# Copy from https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+# Copy from https://github.com/apache/flink/blob/release-1.18.1/tools/azure-pipelines/free_disk_space.sh
 echo "=============================================================================="
 echo "Freeing up disk space on CI system"
 echo "=============================================================================="
@@ -32,7 +32,12 @@ sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable fire
 sudo apt-get autoremove -y
 sudo apt-get clean
 df -h
+
 echo "Removing large directories"
-rm -rf /usr/local/lib/android # release about 10 GB
-rm -rf /usr/share/dotnet # release about 20GB
+rm -rf /usr/local/lib/android
+rm -rf /usr/share/dotnet
+rm -rf /usr/local/graalvm/
+rm -rf /usr/local/.ghcup/
+rm -rf /usr/local/share/powershell
+rm -rf /usr/local/share/chromium
 df -h

--- a/scripts/free-disk-space.sh
+++ b/scripts/free-disk-space.sh
@@ -35,5 +35,4 @@ df -h
 echo "Removing large directories"
 rm -rf /usr/local/lib/android # release about 10 GB
 rm -rf /usr/share/dotnet # release about 20GB
-rm -rf /opt/hostedtoolcache
 df -h

--- a/scripts/free-disk-space.sh
+++ b/scripts/free-disk-space.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Copy from https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+df -h
+echo "Removing large packages"
+sudo apt-get remove -y '^ghc-8.*'
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get autoremove -y
+sudo apt-get clean
+df -h
+echo "Removing large directories"
+rm -rf /usr/local/lib/android # release about 10 GB
+rm -rf /usr/share/dotnet # release about 20GB
+rm -rf /opt/hostedtoolcache
+df -h


### PR DESCRIPTION
## Rationale

CI fails due to no space...
```
Error: No space left on device : '/home/runner/runners/2.313.0/_diag/pages/e678fbe3-017c-41da-8bca-a6d70099419c_0ce2596c-30e4-5db6-a7ae-10ecfd0107a7_1.log'
```
- https://github.com/apache/incubator-horaedb/actions/runs/7974416510/job/21770259595

## Detailed Changes
Refer https://github.com/orgs/community/discussions/25678


## Test Plan
CI