### PR TITLE
fix: bump influxql, fix query priority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,14 @@ on:
       - 'src/**'
       - 'integration_tests/**'
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/ci.yml'
   pull_request:
     paths:
       - 'src/**'
       - 'integration_tests/**'
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/ci.yml'
 
 # Common environment variables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "ahash 0.8.3",
  "arrow 49.0.0",
@@ -2214,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -2836,7 +2836,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "pbjson",
  "pbjson-build",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "arrow 49.0.0",
  "arrow_util",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "arrow 49.0.0",
  "chrono",
@@ -4588,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "tracing",
 ]
@@ -5589,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "arrow 49.0.0",
  "chrono",
@@ -6293,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "arrow 49.0.0",
  "hashbrown 0.13.2",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql.git?rev=b9fb3ca#b9fb3ca59fda99997a51cab7a56d34fb2126dd08"
+source = "git+https://github.com/CeresDB/influxql.git?rev=05a8a9f#05a8a9f79c5b8e3c6d324b214e7ccf910c2f6b73"
 dependencies = [
  "dotenvy",
  "observability_deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,10 +121,10 @@ hash_ext = { path = "src/components/hash_ext" }
 hex = "0.4.3"
 hyperloglog = { git = "https://github.com/jedisct1/rust-hyperloglog.git", rev = "425487ce910f26636fbde8c4d640b538431aad50" }
 id_allocator = { path = "src/components/id_allocator" }
-influxql-logical-planner = { git = "https://github.com/CeresDB/influxql.git", rev = "b9fb3ca", package = "iox_query_influxql" }
-influxql-parser = { git = "https://github.com/CeresDB/influxql.git", rev = "b9fb3ca", package = "influxdb_influxql_parser" }
-influxql-query = { git = "https://github.com/CeresDB/influxql.git", rev = "b9fb3ca", package = "iox_query" }
-influxql-schema = { git = "https://github.com/CeresDB/influxql.git", rev = "b9fb3ca", package = "schema" }
+influxql-logical-planner = { git = "https://github.com/CeresDB/influxql.git", rev = "05a8a9f", package = "iox_query_influxql" }
+influxql-parser = { git = "https://github.com/CeresDB/influxql.git", rev = "05a8a9f", package = "influxdb_influxql_parser" }
+influxql-query = { git = "https://github.com/CeresDB/influxql.git", rev = "05a8a9f", package = "iox_query" }
+influxql-schema = { git = "https://github.com/CeresDB/influxql.git", rev = "05a8a9f", package = "schema" }
 interpreters = { path = "src/interpreters" }
 itertools = "0.10.5"
 lz4_flex = { version = "0.11", default-features = false, features = ["frame"] }

--- a/integration_tests/cases/env/local/ddl/query-plan.result
+++ b/integration_tests/cases/env/local/ddl/query-plan.result
@@ -45,6 +45,16 @@ plan_type,plan,
 String("Plan with Metrics"),String("ScanTable: table=03_dml_select_real_time_range, parallelism=8, priority=High, partition_count=UnknownPartitioning(8), metrics=[\nPredicate { exprs:[t >= TimestampMillisecond(1695348001000, None), t < TimestampMillisecond(1695348002000, None)], time_range:TimeRange { inclusive_start: Timestamp(1695348001000), exclusive_end: Timestamp(1695348002000) } }\nscan_table:\n    do_merge_sort=true\n    iter_num=1\n    merge_iter_0:\n        init_duration=xxs\n        num_memtables=1\n        num_ssts=0\n        scan_count=2\n        scan_duration=xxs\n        times_fetch_row_from_multiple=0\n        times_fetch_rows_from_one=1\n        total_rows_fetch_from_one=1\n        scan_memtable_1, fetched_columns:[tsid,t]:\n=0]\n"),
 
 
+-- This query should have higher priority
+-- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
+-- SQLNESS REPLACE metrics=\[.*?s\] metrics=xx
+explain analyze select name from `03_dml_select_real_time_range`
+where t >= 1695348001000 and t < 1695348002000;
+
+plan_type,plan,
+String("Plan with Metrics"),String("ProjectionExec: expr=[name@0 as name], metrics=xx\n  ScanTable: table=03_dml_select_real_time_range, parallelism=8, priority=High, partition_count=UnknownPartitioning(8), metrics=[\nPredicate { exprs:[t >= TimestampMillisecond(1695348001000, None), t < TimestampMillisecond(1695348002000, None)], time_range:TimeRange { inclusive_start: Timestamp(1695348001000), exclusive_end: Timestamp(1695348002000) } }\nscan_table:\n    do_merge_sort=true\n    iter_num=1\n    merge_iter_0:\n        init_duration=xxs\n        num_memtables=1\n        num_ssts=0\n        scan_count=2\n        scan_duration=xxs\n        times_fetch_row_from_multiple=0\n        times_fetch_rows_from_one=1\n        total_rows_fetch_from_one=1\n        scan_memtable_1, fetched_columns:[tsid,t,name]:\n=0]\n"),
+
+
 -- This query should not include memtable
 -- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
 -- SQLNESS REPLACE metrics=\[.*?s\] metrics=xx

--- a/integration_tests/cases/env/local/ddl/query-plan.sql
+++ b/integration_tests/cases/env/local/ddl/query-plan.sql
@@ -28,6 +28,12 @@ where t > 1695348001000;
 explain analyze select t from `03_dml_select_real_time_range`
 where t >= 1695348001000 and t < 1695348002000;
 
+-- This query should have higher priority
+-- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
+-- SQLNESS REPLACE metrics=\[.*?s\] metrics=xx
+explain analyze select name from `03_dml_select_real_time_range`
+where t >= 1695348001000 and t < 1695348002000;
+
 -- This query should not include memtable
 -- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
 -- SQLNESS REPLACE metrics=\[.*?s\] metrics=xx


### PR DESCRIPTION
## Rationale
When time column is not in `select`, `extract_time_range` will not find time range of one query

## Detailed Changes
- https://github.com/CeresDB/influxql/pull/16

## Test Plan
CI

