### PR TITLE
fix: table blacklist not work for write

### DIFF
--- a/integration_tests/config/horaedb-cluster-0.toml
+++ b/integration_tests/config/horaedb-cluster-0.toml
@@ -55,5 +55,5 @@ timeout = "5s"
 server_addrs = ['127.0.0.1:2379']
 
 [limiter]
-write_block_list = ['mytable1']
-read_block_list = ['mytable1']
+write_block_list = ['block_test_table']
+read_block_list = ['block_test_table']

--- a/integration_tests/config/horaedb-cluster-1.toml
+++ b/integration_tests/config/horaedb-cluster-1.toml
@@ -56,5 +56,5 @@ timeout = "5s"
 server_addrs = ['127.0.0.1:2379']
 
 [limiter]
-write_block_list = ['mytable1']
-read_block_list = ['mytable1']
+write_block_list = ['block_test_table']
+read_block_list = ['block_test_table']

--- a/src/proxy/src/write.rs
+++ b/src/proxy/src/write.rs
@@ -518,7 +518,7 @@ impl Proxy {
                 .box_err()
                 .context(ErrWithCause {
                     code: StatusCode::INTERNAL_SERVER_ERROR,
-                    msg: format!("table is blocked"),
+                    msg: "table is blocked",
                 })?;
 
             let insert_plan = match plan {

--- a/src/proxy/src/write.rs
+++ b/src/proxy/src/write.rs
@@ -510,7 +510,7 @@ impl Proxy {
         // TODO: concurrently run the insert plan here
         for plan in plan_vec {
             // check limit first
-            // TODO: if one table is in blocked, maybe should not lead to failure of whole
+            // TODO: if one table is blocked, maybe should not lead to failure of whole
             // batch?
             self.instance
                 .limiter


### PR DESCRIPTION
## Rationale
Table blocking is found disable in grpc write path, that is annoying... 
This pr fix it for making us happy when handling the problematic tables in production.

## Detailed Changes
- support table blocking in grpc write path.
- add related its.

## Test Plan
CI