### PR TITLE
chore: bump sqlness to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,9 +3770,9 @@ checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "local-ip-address"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885efb07efcd6ae1c6af70be7565544121424fa9e5b1c3e4b58bbbf141a58cef"
+checksum = "612ed4ea9ce5acfb5d26339302528a5e1e59dfed95e9e11af3c083236ff1d15d"
 dependencies = [
  "libc",
  "neli",
@@ -4011,6 +4011,15 @@ checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb3bf58a1ec4f3f228bec851a2066c7717ad308817cd8a08f67c10660c6ff7b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6738,14 +6747,16 @@ dependencies = [
 
 [[package]]
 name = "sqlness"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0860f149718809371602b42573693e1ed2b1d0aed35fe69e04e4e4e9918d81f7"
+checksum = "cf503ec532a37b2444ef9de1f47b2e897b1322d8816d25e1824fc74760d32106"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",
+ "minijinja",
  "prettydiff",
  "regex",
+ "serde_json",
  "thiserror",
  "toml 0.5.11",
  "walkdir",
@@ -7714,7 +7725,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -28,12 +28,12 @@ workspace = true
 workspace = true
 
 [dependencies]
-anyhow = "1.0.58"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait =  { workspace = true }
 horaedb-client = { workspace = true }
 local-ip-address = "0.5"
 reqwest = { workspace = true }
 serde = { workspace = true }
-sqlness = "0.5.0"
+sqlness = "0.6"
 tokio = { workspace = true }
-uuid = { version = "1.3", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -29,7 +29,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait =  { workspace = true }
+async-trait = { workspace = true }
 horaedb-client = { workspace = true }
 local-ip-address = "0.5"
 reqwest = { workspace = true }


### PR DESCRIPTION
## Rationale


## Detailed Changes
See https://github.com/CeresDB/sqlness/releases/tag/v0.6.0

## Test Plan
CI